### PR TITLE
Imap server updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,22 +25,26 @@ The email address is composed like:
 
 ## B. For NextCloud admins to setup
 ### Requirements
-This app requires php-curl, php-imap and Postfix.
+This app requires php-curl, php-imap and some sort of imap server (e.g. Postfix with Courier).
 ### NC new user
 Create a new user from User Management on your NC server, which will have to function as a bot. We chose to call him *deckbot*, but you can call it however you want.<br>
 __Note__: that you have to assign *deckbot* on each board you want to add new cards from email.
-### Set up Postfix for incoming email
+### Configure Email
+#### Option 1 - Set up Postfix for incoming email
 You can setup Posfix mail server folowing the instructions on [Posfix setup](https://docs.gitlab.com/ee/administration/reply_by_email_postfix_setup.html), and after that add "+" delimiter (which separe the user from the board in the email address) using the command:<br>
 ```
 sudo postconf -e "recipient_delimiter = +"
 ```
+#### Option 2 - Use an existing email server.
+This could be any hosted email service. The only requirement is that you can connect to it via the IMAP protocol.
+*Please note this option may not be as flexible as a selfhosted server. For example your email service may not support the "+"delimeter for directing messages to a specific board*
 ### Download and install
-Clone this repository into *incoming* user.<br>
+If using a self-hosted Postfix server, clone this repository into *incoming* user. If not you may need to create a new user on your system and adjust the commands in future steps to match that username.<br>
 ```
 cd /home/incoming/
 git clone https://github.com/putt1ck/mail2deck.git mail2deck
 ```
-Edit as you need the config file: 
+Edit the config file as you need: 
 ```
 sudo nano /home/incoming/mail2deck/config.php
 ```

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ You can setup Posfix mail server folowing the instructions on [Posfix setup](htt
 ```
 sudo postconf -e "recipient_delimiter = +"
 ```
-#### Option 2 - Use an existing email server.
+#### Option 2 - Use an existing email server
 This could be any hosted email service. The only requirement is that you can connect to it via the IMAP protocol.
-*Please note this option may not be as flexible as a selfhosted server. For example your email service may not support the "+"delimeter for directing messages to a specific board*
+*Please note this option may not be as flexible as a self-hosted server. For example your email service may not support the "+"delimiter for directing messages to a specific board.*
 ### Download and install
-If using a self-hosted Postfix server, clone this repository into *incoming* user. If not you may need to create a new user on your system and adjust the commands in future steps to match that username.<br>
+If using a self-hosted Postfix server, clone this repository into the home directory of the *incoming* user. If not self-hosting, you may need to create a new user on your system and adjust the commands in future steps to match that username.<br>
 ```
 cd /home/incoming/
 git clone https://github.com/putt1ck/mail2deck.git mail2deck
@@ -48,6 +48,7 @@ Edit the config file as you need:
 ```
 sudo nano /home/incoming/mail2deck/config.php
 ```
+*You can refer to https://www.php.net/manual/en/function.imap-open.php for setting the value of MAIL_SERVER_FLAGS*
 ### Add a cronjob which will run mail2deck.
 ```
 sudo crontab -u incoming -e

--- a/config.php
+++ b/config.php
@@ -3,7 +3,7 @@ define("NC_SERVER", ""); // server.domain
 define("NC_USER", "deckbot");
 define("NC_PASSWORD", "");
 define("MAIL_SERVER", ""); // server.domain
-define("MAIL_SERVER_FLAGS", "/no-validate-cert" // flags needed to connect to server. Refer to https://www.php.net/manual/en/function.imap-open.php for a list of valid flags.
+define("MAIL_SERVER_FLAGS", "/no-validate-cert"); // flags needed to connect to server. Refer to https://www.php.net/manual/en/function.imap-open.php for a list of valid flags.
 define("MAIL_USER", "incoming");
 define("MAIL_PASSWORD", "");
 ?>

--- a/config.php
+++ b/config.php
@@ -3,6 +3,7 @@ define("NC_SERVER", ""); // server.domain
 define("NC_USER", "deckbot");
 define("NC_PASSWORD", "");
 define("MAIL_SERVER", ""); // server.domain
+define("MAIL_SERVER_FLAGS", "/no-validate-cert" // flags needed to connect to server. Refer to https://www.php.net/manual/en/function.imap-open.php for a list of valid flags.
 define("MAIL_USER", "incoming");
 define("MAIL_PASSWORD", "");
 ?>

--- a/index.php
+++ b/index.php
@@ -3,7 +3,7 @@ error_reporting(E_ERROR | E_PARSE);
 require_once("config.php");
 require_once('lib/DeckClass.php');
 
-$inbox = imap_open("{" . MAIL_SERVER . "/imap/novalidate-cert}INBOX", MAIL_USER, MAIL_PASSWORD)
+$inbox = imap_open("{" . MAIL_SERVER . "/imap" . MAIL_SERVER_FLAGS . "}INBOX", MAIL_USER, MAIL_PASSWORD)
         or die("can't connect:" . imap_last_error());
 
 $emails = imap_search($inbox, 'UNSEEN');


### PR DESCRIPTION
Allow flags for connecting to IMAP server to be specified in config.php and update README to show how to use a non-self-hosted IMAP server. This is an implementation to resolve #9.