### PR TITLE
fixes newroco/mail2deck#11 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The email address is composed like:
 
 ## B. For NextCloud admins to setup
 ### Requirements
-This app requires php-curl, php-imap and some sort of imap server (e.g. Postfix with Courier).
+This app requires php-curl, php-mbstring ,php-imap and some sort of imap server (e.g. Postfix with Courier).
 ### NC new user
 Create a new user from User Management on your NC server, which will have to function as a bot. We chose to call him *deckbot*, but you can call it however you want.<br>
 __Note__: that you have to assign *deckbot* on each board you want to add new cards from email.

--- a/config.php
+++ b/config.php
@@ -6,4 +6,5 @@ define("MAIL_SERVER", ""); // server.domain
 define("MAIL_SERVER_FLAGS", "/no-validate-cert"); // flags needed to connect to server. Refer to https://www.php.net/manual/en/function.imap-open.php for a list of valid flags.
 define("MAIL_USER", "incoming");
 define("MAIL_PASSWORD", "");
+define("DECODE_SPECIAL_CHARACTERS", true); //requires mbstring, if false special characters (like öäüß) won't be displayed correctly
 ?>

--- a/index.php
+++ b/index.php
@@ -80,8 +80,8 @@ if ($emails)
             $message = imap_fetchbody($inbox, $emails[$j], 1);
         }
         $mailData = new stdClass();
-        $mailData->mailSubject = $overview->subject;
-        $mailData->mailMessage = $message;
+        $mailData->mailSubject = DECODE_SPECIAL_CHARACTERS ? mb_decode_mimeheader($overview->subject) : $overview->subject;
+        $mailData->mailMessage = DECODE_SPECIAL_CHARACTERS ? quoted_printable_decode($message) : $message;
         $mailData->from = $overview->from[0]->mailbox . '@' . $overview->from[0]->host;
 
         $newcard = new DeckClass();


### PR DESCRIPTION
Add support for special characters in subject and body. Requires php-mbstring. Can be disabled via new config option (DECODE_SPECIAL_CHARACTERS). The default should be enabled to support more languages without additional configuration.

Without fix:
<img width="438" alt="Bildschirmfoto 2022-01-15 um 18 07 48" src="https://user-images.githubusercontent.com/22852640/149631561-2bfcde02-b920-4aef-8cc2-6b06ba256f67.png">

With fix:
<img width="449" alt="Bildschirmfoto 2022-01-15 um 18 12 38" src="https://user-images.githubusercontent.com/22852640/149631572-e0a73161-408e-4762-93d1-f9eab0e5c84d.png">
