### PR TITLE
Add check for MIME encoded messages

### DIFF
--- a/index.php
+++ b/index.php
@@ -73,11 +73,15 @@ if ($emails)
         $data->title = DECODE_SPECIAL_CHARACTERS ? mb_decode_mimeheader($overview->subject) : $overview->subject;
         $data->type = "plain";
         $data->order = -time();
+        $body = $inbox->fetchMessageBody($emails[$j], 1.1);
+        if ($body == "") {
+            $body = $inbox->fetchMessageBody($emails[$j], 1);
+        }
         if(count($attachments)) {
             $data->attachments = $attNames;
-            $description = DECODE_SPECIAL_CHARACTERS ? quoted_printable_decode($inbox->fetchMessageBody($emails[$j], 1.1)) : $inbox->fetchMessageBody($emails[$j], 1.1);
+            $description = DECODE_SPECIAL_CHARACTERS ? quoted_printable_decode($body) : $body;
         } else {
-            $description = DECODE_SPECIAL_CHARACTERS ? quoted_printable_decode($inbox->fetchMessageBody($emails[$j], 1)) : $inbox->fetchMessageBody($emails[$j], 1);
+            $description = DECODE_SPECIAL_CHARACTERS ? quoted_printable_decode($body) : $body;
         }
         if($base64encode) {
             $description = base64_decode($description);


### PR DESCRIPTION
As far as I understand MIME-encoded message can be broken down into parts based upon its contents. While most mail programs add the plain text part as the first part this is not true for all programs. In fact mail2deck couldn't import the body when processing certain plain text mails with attachments - because the plain text part wasn't  at position 1.1.

With this fix imap_fetchbody requests sub-part 1 of part 1 and, if it is empty/ non-existent, it requests part 1.