### PR TITLE
feat: adds optional duedate to card

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ Here's how the email subject should look like:
 * *You can use single or double quotes.*
 * *Case-insensitive for board, stack and user respectively.*
 
+### 2.4: Specify due date
+You can use the optional parameter `d-` to add a due date to a card.
+Here's how the email subject should look like if you want to set a due date to the card:
+
+`Update website logo b-'website' s-'to do' u-'bob' d-'2022-08-22T19:29:30+00:00'`
+
+* *You can use single or double quotes.*
+
 # ⚙️ B. For NextCloud admins to setup
 ## Requirements
 This app requires php-curl, php-mbstring ,php-imap and some sort of imap server (e.g. Postfix with Courier).

--- a/lib/DeckClass.php
+++ b/lib/DeckClass.php
@@ -51,6 +51,10 @@ class DeckClass {
             $userFromMail = $m[1];
             $params = str_replace($m[0], '', $params);
         }
+        if(preg_match('/d-"([^"]+)"/', $params, $m) || preg_match("/d-'([^']+)'/", $params, $m)) {
+            $duedateFromMail = $m[1];
+            $params = str_replace($m[0], '', $params);
+        }
 
         $boards = $this->apiCall("GET", NC_SERVER . "/index.php/apps/deck/api/v1.0/boards");
         $boardId = $boardName = null;
@@ -83,6 +87,7 @@ class DeckClass {
         $boardStack->newTitle = $params;
         $boardStack->boardTitle = $boardName;
         $boardStack->userId = $userFromMail;
+        $boardStack->dueDate = $duedateFromMail;
 
         return $boardStack;
     }
@@ -92,12 +97,13 @@ class DeckClass {
 
         if($params) {
             $data->title = $params->newTitle;
+            $data->duedate = $params->dueDate;
             $card = $this->apiCall("POST", NC_SERVER . "/index.php/apps/deck/api/v1.0/boards/{$params->board}/stacks/{$params->stack}/cards", $data);
             $card->board = $params->board;
             $card->stack = $params->stack;
 
             if ($params->userId) $user->userId = $params->userId;
-
+            
             if($this->responseCode == 200) {
                 if(ASSIGN_SENDER || $params->userId) $this->assignUser($card, $user);
                 if($data->attachments) $this->addAttachments($card, $data->attachments);


### PR DESCRIPTION
Needed a case where I could add a due date from my external application so I want to contribute it.
Used the optional parameters as described in [REST API docs](https://deck.readthedocs.io/en/latest/API/#cards)
Signed-off-by: Adrian Missy <adrian.missy@onewavestudios.com>